### PR TITLE
task: Add title length constraint for recipe revisions

### DIFF
--- a/api/services/recipe/recipe.go
+++ b/api/services/recipe/recipe.go
@@ -24,6 +24,16 @@ const (
 	DEFAULT_LIST_RECIPE_SORT_FIELD = "publish_date"
 )
 
+func validateTitle(title string) error {
+	if len(title) < 3 {
+		return fmt.Errorf("title must be at least 3 characters long")
+	}
+	if len(title) > 150 {
+		return fmt.Errorf("title must be no more than 150 characters long")
+	}
+	return nil
+}
+
 type RecipeService interface {
 	GetRecipeByID(ctx context.Context, id uuid.UUID) (*model.Recipe, error)
 	GetRecipeBySlug(ctx context.Context, slug string, displayName string) (*model.Recipe, error)
@@ -142,6 +152,10 @@ func (r recipeService) AddRecipeRevision(ctx context.Context, input model.AddRev
 		return nil, nil
 	}
 
+	if err := validateTitle(input.Revision.Title); err != nil {
+		return nil, err
+	}
+
 	tx, err := r.conn.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -246,6 +260,10 @@ func (r recipeService) CreateRecipe(ctx context.Context, input model.CreateRecip
 	if input.Revision == nil {
 		// TODO: Write an actual error here
 		return nil, nil
+	}
+
+	if err := validateTitle(input.Revision.Title); err != nil {
+		return nil, err
 	}
 
 	user, _ := r.authService.GetUserSessionFromCtx(ctx)

--- a/db/migrations/20250812230844_add_title_length_constraint.down.sql
+++ b/db/migrations/20250812230844_add_title_length_constraint.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE recipe_revisions
+DROP CONSTRAINT title_length_check;

--- a/db/migrations/20250812230844_add_title_length_constraint.up.sql
+++ b/db/migrations/20250812230844_add_title_length_constraint.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE recipe_revisions
+ADD CONSTRAINT title_length_check
+CHECK (char_length(trim(title)) >= 3 AND char_length(trim(title)) <= 150);


### PR DESCRIPTION
## Description

Added a database migration to enforce title length constraints on the recipe_revisions table. This ensures that recipe titles are meaningful and within reasonable bounds.

The constraint requires that recipe titles, when trimmed of whitespace, have a length between 3 and 150 characters. This prevents both empty/too-short titles and excessively long titles that could cause display issues.

- Created migration files for adding/dropping the title_length_check constraint
- Updated recipe service to handle the new constraint
- Migration includes proper up/down scripts for safe deployment

Tested the constraint enforcement using GraphQL playground with a title exceeding less than 3 characters as well as over 150 characters:

```graphql
mutation checkTitleLength {
  recipe {
    create(input: {slug: "unique-slug-n", revision: {
      title: "", 
      tags: [], ingredients: [], steps: []
    }, private: true}) {
      id
    }
  }
}
```
Note: task migrate-up currently fails due to existing data in the database that violates the new constraint. This is expected behavior and will require data cleanup before the migration can be applied in production.

## Checklist

- [ x ] I have tested these changes
- [ x ] I have updated documentation as needed

## Related Issues

Closes #72 
